### PR TITLE
Remove paths flaws

### DIFF
--- a/MhwModManager/App.xaml.cs
+++ b/MhwModManager/App.xaml.cs
@@ -60,7 +60,7 @@ namespace MhwModManager
             {
                 var result = MessageBox.Show("A new version is available, do you want to download it now ?", "MHW Mod Manager", MessageBoxButton.YesNo, MessageBoxImage.Information);
                 if (result == MessageBoxResult.Yes)
-                    System.Diagnostics.Process.Start("https://github.com/oxypomme/MhwModManager/releases");
+                    System.Diagnostics.Process.Start("https://github.com/oxypomme/SimpleMhwModManager/releases/latest");
             }
         }
     }

--- a/MhwModManager/App.xaml.cs
+++ b/MhwModManager/App.xaml.cs
@@ -15,7 +15,9 @@ namespace MhwModManager
     /// </summary>
     public partial class App : Application
     {
+        public static string AppData = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "SMMM");
         public static Setting Settings = new Setting();
+        public static string SettingsPath = Path.Combine(AppData, "settings.json");
 
         public App()
         {

--- a/MhwModManager/App.xaml.cs
+++ b/MhwModManager/App.xaml.cs
@@ -16,6 +16,7 @@ namespace MhwModManager
     public partial class App : Application
     {
         public static string AppData = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "SMMM");
+        public static string ModsPath = Path.Combine(AppData, "mods");
         public static Setting Settings = new Setting();
         public static string SettingsPath = Path.Combine(AppData, "settings.json");
 
@@ -39,10 +40,11 @@ namespace MhwModManager
         public static List<string> GetMods()
         {
             var modList = new List<string>();
-            var modFolder = new DirectoryInfo("mods");
 
-            if (!Directory.Exists("mods"))
-                Directory.CreateDirectory("mods");
+            if (!Directory.Exists(ModsPath))
+                Directory.CreateDirectory(ModsPath);
+
+            var modFolder = new DirectoryInfo(ModsPath);
 
             foreach (var mod in modFolder.GetDirectories())
                 modList.Add(mod.Name);

--- a/MhwModManager/App.xaml.cs
+++ b/MhwModManager/App.xaml.cs
@@ -25,7 +25,7 @@ namespace MhwModManager
             Settings.GenConfig();
             if (!Directory.Exists(Settings.settings.mhw_path))
             {
-                MessageBox.Show("The path to MHW is wrong, please correct it !", "MHW Mod Manager", MessageBoxButton.OK, MessageBoxImage.Error);
+                MessageBox.Show("The path to MHW is not found, you have to install the game first, or if the game is already installed, open it", "MHW Mod Manager", MessageBoxButton.OK, MessageBoxImage.Error);
                 var dialog = new WinForms.FolderBrowserDialog();
                 if (dialog.ShowDialog() == WinForms.DialogResult.OK)
                 {

--- a/MhwModManager/MainWindow.xaml.cs
+++ b/MhwModManager/MainWindow.xaml.cs
@@ -71,7 +71,7 @@ namespace MhwModManager
                 Directory.CreateDirectory(tmpFolder);
             if (dialog.ShowDialog() == true)
             {
-                ZipFile.ExtractToDirectory(dialog.FileName, Path.GetTempPath());
+                ZipFile.ExtractToDirectory(dialog.FileName, tmpFolder);
                 foreach (var dir in Directory.GetDirectories(tmpFolder))
                 {
                     if (dir.Contains("nativePC"))

--- a/MhwModManager/MainWindow.xaml.cs
+++ b/MhwModManager/MainWindow.xaml.cs
@@ -66,20 +66,23 @@ namespace MhwModManager
             var dialog = new OpenFileDialog();
             dialog.DefaultExt = "zip";
             dialog.Filter = "zip files (*.zip)|*.zip|rar files (*.rar)|*.rar";
+            var tmpFolder = Path.Combine(Path.GetTempPath(), "SMMMaddMod");
+            if (!Directory.Exists(tmpFolder))
+                Directory.CreateDirectory(tmpFolder);
             if (dialog.ShowDialog() == true)
             {
-                ZipFile.ExtractToDirectory(dialog.FileName, "mods/tmp");
-                foreach (var dir in Directory.GetDirectories("mods/tmp"))
+                ZipFile.ExtractToDirectory(dialog.FileName, Path.GetTempPath());
+                foreach (var dir in Directory.GetDirectories(tmpFolder))
                 {
                     if (dir.Contains("nativePC"))
                     {
                         var name = dialog.FileName.Split('\\');
                         var modName = name[name.GetLength(0) - 1].Split('.')[0];
-                        if (!Directory.Exists("mods/" + modName))
-                            Directory.Move(dir, @"mods\" + modName);
+                        if (!Directory.Exists(Path.Combine(App.ModsPath, modName)))
+                            Directory.Move(dir, Path.Combine(App.ModsPath, modName));
                         else
                             MessageBox.Show("This mod is already installed", "MHW Mod Manager", MessageBoxButton.OK, MessageBoxImage.Information);
-                        Directory.Delete("mods/tmp/", true);
+                        Directory.Delete(tmpFolder, true);
                     }
                 }
             }

--- a/MhwModManager/MainWindow.xaml.cs
+++ b/MhwModManager/MainWindow.xaml.cs
@@ -110,8 +110,10 @@ namespace MhwModManager
         private void remMod_Click(object sender, RoutedEventArgs e)
         {
             foreach (var mod in modListBox.SelectedItems)
+            {
                 Directory.Delete(Path.Combine(App.ModsPath, (mod as CheckBox).Content.ToString()), true);
                 App.Settings.settings.mod_installed.RemoveAt(int.Parse((mod as CheckBox).Tag.ToString()));
+            }
             UpdateModsList();
         }
 

--- a/MhwModManager/MainWindow.xaml.cs
+++ b/MhwModManager/MainWindow.xaml.cs
@@ -92,13 +92,13 @@ namespace MhwModManager
         private void remMod_Click(object sender, RoutedEventArgs e)
         {
             foreach (var mod in modListBox.SelectedItems)
-                Directory.Delete(@"mods\" + (mod as CheckBox).Content.ToString() + @"\", true);
+                Directory.Delete(Path.Combine(App.ModsPath, (mod as CheckBox).Content.ToString()), true);
             UpdateModsList();
         }
 
         private void startGame_Click(object sender, RoutedEventArgs e)
         {
-            Process.Start(App.Settings.settings.mhw_path + "\\MonsterHunterWorld.exe");
+            Process.Start(Path.Combine(App.Settings.settings.mhw_path, "MonsterHunterWorld.exe"));
         }
 
         private void refreshMod_Click(object sender, RoutedEventArgs e)
@@ -119,13 +119,13 @@ namespace MhwModManager
         {
             if ((sender as CheckBox).IsChecked.Value == true)
             {
-                DirectoryCopy("mods/" + (sender as CheckBox).Content.ToString(), App.Settings.settings.mhw_path + "\\nativePC", true);
+                DirectoryCopy(Path.Combine(App.ModsPath, (sender as CheckBox).Content.ToString()), Path.Combine(App.Settings.settings.mhw_path + "nativePC"), true);
                 App.Settings.settings.mod_installed[int.Parse((sender as CheckBox).Tag.ToString())] = true;
             }
             else
             {
-                DeleteMod("mods/" + (sender as CheckBox).Content.ToString(), App.Settings.settings.mhw_path + "\\nativePC\\");
-                CleanNativePC(App.Settings.settings.mhw_path + "\\nativePC\\");
+                DeleteMod(Path.Combine(App.ModsPath, (sender as CheckBox).Content.ToString()), Path.Combine(App.Settings.settings.mhw_path + "nativePC"));
+                CleanNativePC(Path.Combine(App.Settings.settings.mhw_path + "nativePC"));
                 App.Settings.settings.mod_installed[int.Parse((sender as CheckBox).Tag.ToString())] = false;
             }
             App.Settings.ParseSettingsJSON();

--- a/MhwModManager/MainWindow.xaml.cs
+++ b/MhwModManager/MainWindow.xaml.cs
@@ -119,12 +119,12 @@ namespace MhwModManager
         {
             if ((sender as CheckBox).IsChecked.Value == true)
             {
-                DirectoryCopy(Path.Combine(App.ModsPath, (sender as CheckBox).Content.ToString()), Path.Combine(App.Settings.settings.mhw_path + "nativePC"), true);
+                DirectoryCopy(Path.Combine(App.ModsPath, (sender as CheckBox).Content.ToString()), Path.Combine(App.Settings.settings.mhw_path, "nativePC"), true);
                 App.Settings.settings.mod_installed[int.Parse((sender as CheckBox).Tag.ToString())] = true;
             }
             else
             {
-                DeleteMod(Path.Combine(App.ModsPath, (sender as CheckBox).Content.ToString()), Path.Combine(App.Settings.settings.mhw_path + "nativePC"));
+                DeleteMod(Path.Combine(App.ModsPath, (sender as CheckBox).Content.ToString()), Path.Combine(App.Settings.settings.mhw_path, "nativePC"));
                 CleanNativePC(Path.Combine(App.Settings.settings.mhw_path + "nativePC"));
                 App.Settings.settings.mod_installed[int.Parse((sender as CheckBox).Tag.ToString())] = false;
             }

--- a/MhwModManager/MhwModManager.csproj
+++ b/MhwModManager/MhwModManager.csproj
@@ -75,6 +75,9 @@
     <SignManifests>true</SignManifests>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Gameloop.Vdf, Version=0.5.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Gameloop.Vdf.0.5.0\lib\net45\Gameloop.Vdf.dll</HintPath>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>

--- a/MhwModManager/SettingsDialog.xaml.cs
+++ b/MhwModManager/SettingsDialog.xaml.cs
@@ -5,33 +5,17 @@ using System.Windows;
 
 namespace MhwModManager
 {
-    /// <summary>
-    /// Logique d'interaction pour SettingsDialog.xaml
-    /// </summary>
-    public partial class SettingsDialog : Window
-    {
-        public SettingsDialog()
-        {
-            InitializeComponent();
-        }
-    }
-
     public class Setting
     {
-        public struct Settings
-        {
-            public bool dark_mode;
-            public string mhw_path;
-            public List<bool> mod_installed;
-        }
-
         public Settings settings = new Settings();
 
         public void GenConfig()
         {
-            if (!File.Exists("settings.json"))
+            if (!File.Exists(App.SettingsPath))
             {
-                File.Create("settings.json").Close();
+                if (!Directory.Exists(App.AppData))
+                    Directory.CreateDirectory(App.AppData);
+                File.Create(App.SettingsPath).Close();
 
                 settings.dark_mode = false;
                 settings.mhw_path = @"C:\Program Files (x86)\Steam\steamapps\common\Monster Hunter World";
@@ -42,7 +26,7 @@ namespace MhwModManager
             else
             {
                 Setting sets;
-                using (StreamReader file = new StreamReader("settings.json"))
+                using (StreamReader file = new StreamReader(App.SettingsPath))
                 {
                     sets = JsonConvert.DeserializeObject<Setting>(file.ReadToEnd());
                     file.Close();
@@ -56,11 +40,29 @@ namespace MhwModManager
 
         public void ParseSettingsJSON()
         {
-            using (StreamWriter file = new StreamWriter("settings.json"))
+            using (StreamWriter file = new StreamWriter(App.SettingsPath))
             {
                 file.Write(JsonConvert.SerializeObject(this));
                 file.Close();
             }
+        }
+
+        public struct Settings
+        {
+            public bool dark_mode;
+            public string mhw_path;
+            public List<bool> mod_installed;
+        }
+    }
+
+    /// <summary>
+    /// Logique d'interaction pour SettingsDialog.xaml
+    /// </summary>
+    public partial class SettingsDialog : Window
+    {
+        public SettingsDialog()
+        {
+            InitializeComponent();
         }
     }
 }

--- a/MhwModManager/SettingsDialog.xaml.cs
+++ b/MhwModManager/SettingsDialog.xaml.cs
@@ -1,7 +1,9 @@
 ﻿using Newtonsoft.Json;
 using System.Collections.Generic;
 using System.IO;
+using Microsoft.Win32;
 using System.Windows;
+using System;
 
 namespace MhwModManager
 {
@@ -9,18 +11,41 @@ namespace MhwModManager
     {
         public Settings settings = new Settings();
 
+        public static string FindMHWInstallFolder()
+        {
+            var steamRoot = Registry.GetValue(@"HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\Valve\Steam", "InstallPath", null) as string;
+            var libFolders = new List<string>();
+            libFolders.Add(Path.Combine(steamRoot));
+            dynamic libraryfolders = Gameloop.Vdf.VdfConvert.Deserialize(File.ReadAllText(Path.Combine(steamRoot, "steamapps", "libraryfolders.vdf")));
+            try
+            {
+                for (int i = 1; ; i++)
+                    libFolders.Add(libraryfolders.Value[i.ToString()].ToString());
+            }
+            catch (Exception) { }
+            const string appid = "582010";
+            foreach (var folder in libFolders)
+                foreach (var file in new DirectoryInfo(Path.Combine(folder, "steamapps")).GetFiles())
+                    if (file.Extension == ".acf")
+                        using (var text = file.OpenText())
+                        {
+                            dynamic content = Gameloop.Vdf.VdfConvert.Deserialize(text.ReadToEnd());
+                            if (content.Value.appid.ToString() == appid)
+                                return Path.Combine(file.DirectoryName, "common", content.Value.installdir.ToString());
+                        }
+            return null;
+        }
+
         public void GenConfig()
         {
             if (!File.Exists(App.SettingsPath))
             {
                 if (!Directory.Exists(App.AppData))
                     Directory.CreateDirectory(App.AppData);
-                File.Create(App.SettingsPath).Close();
 
                 settings.dark_mode = false;
-                settings.mhw_path = @"C:\Program Files (x86)\Steam\steamapps\common\Monster Hunter World";
+                settings.mhw_path = FindMHWInstallFolder();
                 settings.mod_installed = new List<bool>();
-
                 ParseSettingsJSON();
             }
             else
@@ -33,6 +58,8 @@ namespace MhwModManager
                 }
 
                 settings.dark_mode = sets.settings.dark_mode;
+                if (!Directory.Exists(sets.settings.mhw_path))
+                    sets.settings.mhw_path = FindMHWInstallFolder();
                 settings.mhw_path = sets.settings.mhw_path;
                 settings.mod_installed = sets.settings.mod_installed;
             }
@@ -42,7 +69,7 @@ namespace MhwModManager
         {
             using (StreamWriter file = new StreamWriter(App.SettingsPath))
             {
-                file.Write(JsonConvert.SerializeObject(this));
+                file.Write(JsonConvert.SerializeObject(this, Formatting.Indented));
                 file.Close();
             }
         }

--- a/MhwModManager/SettingsDialog.xaml.cs
+++ b/MhwModManager/SettingsDialog.xaml.cs
@@ -4,53 +4,10 @@ using System.IO;
 using Microsoft.Win32;
 using System.Windows;
 using WinForms = System.Windows.Forms;
+using System;
 
 namespace MhwModManager
 {
-    /// <summary>
-    /// Logique d'interaction pour SettingsDialog.xaml
-    /// </summary>
-    public partial class SettingsDialog : Window
-    {
-        public SettingsDialog()
-        {
-            InitializeComponent();
-            InitializeSettings();
-        }
-
-        private void InitializeSettings()
-        {
-            pathTB.Text = App.Settings.settings.mhw_path;
-            darkmodeCB.IsChecked = App.Settings.settings.dark_mode;
-        }
-
-        private void validateBTN_Click(object sender, RoutedEventArgs e)
-        {
-            App.Settings.ParseSettingsJSON();
-        }
-
-        private void cancelBTN_Click(object sender, RoutedEventArgs e)
-        {
-            Close();
-        }
-
-        private void darkmodeCB_Checked(object sender, RoutedEventArgs e)
-        {
-            App.Settings.settings.dark_mode = darkmodeCB.IsChecked.Value;
-            if (App.Settings.settings.dark_mode)
-                darkmodeCB.Content = "Enabled";
-            else
-                darkmodeCB.Content = "Disabled";
-        }
-
-        private void browseBTN_Click(object sender, RoutedEventArgs e)
-        {
-            var dialog = new WinForms.FolderBrowserDialog();
-            if (dialog.ShowDialog() == WinForms.DialogResult.OK)
-                App.Settings.settings.mhw_path = dialog.SelectedPath;
-        }
-    }
-
     public class Setting
     {
         public Settings settings = new Settings();
@@ -134,6 +91,39 @@ namespace MhwModManager
         public SettingsDialog()
         {
             InitializeComponent();
+            InitializeSettings();
+        }
+
+        private void browseBTN_Click(object sender, RoutedEventArgs e)
+        {
+            var dialog = new WinForms.FolderBrowserDialog();
+            if (dialog.ShowDialog() == WinForms.DialogResult.OK)
+                App.Settings.settings.mhw_path = dialog.SelectedPath;
+        }
+
+        private void cancelBTN_Click(object sender, RoutedEventArgs e)
+        {
+            Close();
+        }
+
+        private void darkmodeCB_Checked(object sender, RoutedEventArgs e)
+        {
+            App.Settings.settings.dark_mode = darkmodeCB.IsChecked.Value;
+            if (App.Settings.settings.dark_mode)
+                darkmodeCB.Content = "Enabled";
+            else
+                darkmodeCB.Content = "Disabled";
+        }
+
+        private void InitializeSettings()
+        {
+            pathTB.Text = App.Settings.settings.mhw_path;
+            darkmodeCB.IsChecked = App.Settings.settings.dark_mode;
+        }
+
+        private void validateBTN_Click(object sender, RoutedEventArgs e)
+        {
+            App.Settings.ParseSettingsJSON();
         }
     }
 }

--- a/MhwModManager/packages.config
+++ b/MhwModManager/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Gameloop.Vdf" version="0.5.0" targetFramework="net48" />
   <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net48" />
   <package id="Octokit" version="0.36.0" targetFramework="net48" />
 </packages>


### PR DESCRIPTION
##  Changelog

* way better way to find the installation path to MHW (looks in the Steam game folders).
* every data from the application is saved into the AppData folder, to avoid the app to be run as administrator if installed in the Program Files (which requires admin rights).
* temporary mod files are located in the temp folder provided by the OS instead of "mods/tmp"