### PR TITLE
More mod structures supported

### DIFF
--- a/MhwModManager/App.xaml.cs
+++ b/MhwModManager/App.xaml.cs
@@ -95,37 +95,81 @@ namespace MhwModManager
 
                     // Get the name of the extracted folder (without the .zip at the end), not the
                     // full path
-                    if (!InstallMod(tmpFolder, splittedPath[splittedPath.GetLength(0) - 1].Split('.')[0]))
-                        // If the install fail
-                        MessageBox.Show("nativePC not found... Please check if it's exist in the mod...", "Simple MHW Mod Manager", MessageBoxButton.OK, MessageBoxImage.Error);
-                    Directory.Delete(tmpFolder, true);
+                    InstallMod(tmpFolder, splittedPath[splittedPath.GetLength(0) - 1].Split('.')[0]);
+                    try
+                    {
+                        Directory.Delete(tmpFolder, true);
+                    }
+                    catch (DirectoryNotFoundException)
+                    {
+                        //the folder may be missing if it has no nativePC and moved the entire folder, deleting it
+                    }
 
                     GetMods(); // Refresh the modlist
                 }
                 MhwModManager.MainWindow.Instance.UpdateModsList();
             }
-            catch (Exception ex) { logStream.Error(ex.Message); }
+            catch (Exception ex) { logStream.Error(ex); }
+        }
+
+        public static string[] GetRecursiveDirectories(string path)
+        {
+            var paths = new List<string>();
+            void addDir(string p)
+            {
+                paths.Add(p);
+                foreach (var item in Directory.GetDirectories(p))
+                    addDir(item);
+            }
+            addDir(path);
+            return paths.ToArray();
         }
 
         public static bool InstallMod(string path, string name)
         {
-            foreach (var dir in Directory.GetDirectories(path))
+            if (Directory.Exists(Path.Combine(ModsPath, name)))
+            // If the mod is installed
             {
-                if (dir.Equals(Path.Combine(path, "nativePC"), StringComparison.OrdinalIgnoreCase))
+                MessageBox.Show("This mod is already installed", "Simple MHW Mod Manager", MessageBoxButton.OK, MessageBoxImage.Information);
+                return true;
+            }
+
+            var nativePCs = new List<string>();
+            foreach (var dir in GetRecursiveDirectories(path))
+            {
+                if (Path.GetFileName(dir).Equals("nativePC", StringComparison.OrdinalIgnoreCase))
                 {
-                    if (!Directory.Exists(Path.Combine(ModsPath, name)))
-                        // If the mod isn't installed
-                        MoveDirectory(dir, Path.Combine(ModsPath, name));
-                    else
-                        MessageBox.Show("This mod is already installed", "Simple MHW Mod Manager", MessageBoxButton.OK, MessageBoxImage.Information);
+                    nativePCs.Add(dir);
+                    logStream.Log(Path.Combine(name, dir.Substring(path.Length + 1)) + " found.");
+                }
+            }
+            if (nativePCs.Count == 1)
+            {
+                MoveDirectory(nativePCs.First(), Path.Combine(ModsPath, name));
+                return true;
+            }
+            else if (nativePCs.Count == 0)
+            {
+                logStream.Warning("No nativePC found.");
+                if (MessageBox.Show("No nativePC found, add the entire file as the nativePC folder ?", "Simple MHW Mod Manager", MessageBoxButton.YesNo, MessageBoxImage.Warning) == MessageBoxResult.Yes)
+                {
+                    MoveDirectory(path, Path.Combine(ModsPath, name));
                     return true;
                 }
                 else
-                {
-                    InstallMod(dir, name);
-                }
+                    return false;
             }
-            return false;
+            else
+            {
+                var dialog = new nativePcPicker(nativePCs.Select(str => str.Substring(path.Length + 1)));
+                if (dialog.ShowDialog() == true)
+                {
+                    MoveDirectory(Path.Combine(path, dialog.Value), Path.Combine(ModsPath, name));
+                    return true;
+                }
+                else
+                    return false;
+            }
         }
 
         public static void ReloadTheme()

--- a/MhwModManager/MhwModManager.csproj
+++ b/MhwModManager/MhwModManager.csproj
@@ -136,6 +136,9 @@
     </Compile>
     <Compile Include="LogStream.cs" />
     <Compile Include="ModInfo.cs" />
+    <Compile Include="nativePcPicker.xaml.cs">
+      <DependentUpon>nativePcPicker.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Setting.cs" />
     <Compile Include="SettingsDialog.xaml.cs">
       <DependentUpon>SettingsDialog.xaml</DependentUpon>
@@ -157,6 +160,10 @@
       <DependentUpon>MainWindow.xaml</DependentUpon>
       <SubType>Code</SubType>
     </Compile>
+    <Page Include="nativePcPicker.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="SettingsDialog.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>

--- a/MhwModManager/nativePcPicker.xaml
+++ b/MhwModManager/nativePcPicker.xaml
@@ -1,0 +1,15 @@
+﻿<Window x:Class="MhwModManager.nativePcPicker"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:local="clr-namespace:MhwModManager"
+        mc:Ignorable="d"
+        WindowStartupLocation="CenterOwner"
+        Title="Pick a nativePC folder" Height="250" Width="300">
+    <Grid>
+        <TextBlock Text="Multiple nativePC found, select which one to add :" Margin="5" VerticalAlignment="Top" />
+        <ListView x:Name="pathList" Margin="5,25,5,35" ScrollViewer.HorizontalScrollBarVisibility="Hidden" SelectionChanged="pathList_SelectionChanged" />
+        <Button Name="installButton" Content="Install" VerticalAlignment="Bottom" HorizontalAlignment="Right" Height="25" Width="75" Margin="5" IsEnabled="False" Click="installButton_Click" />
+    </Grid>
+</Window>

--- a/MhwModManager/nativePcPicker.xaml.cs
+++ b/MhwModManager/nativePcPicker.xaml.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Shapes;
+
+namespace MhwModManager
+{
+    /// <summary>
+    /// Logique d'interaction pour nativePcPicker.xaml
+    /// </summary>
+    public partial class nativePcPicker : Window
+    {
+        #region Public Constructors
+
+        public nativePcPicker(IEnumerable<string> values)
+        {
+            InitializeComponent();
+            foreach (var value in values)
+                pathList.Items.Add(value);
+            if (pathList.Items.Count > 0)
+                pathList.SelectedIndex = 0;
+            MakeDarkTheme();
+        }
+
+        #endregion Public Constructors
+
+        #region Public Properties
+
+        public string Value { get; private set; }
+
+        #endregion Public Properties
+
+        #region Private Methods
+
+        private void installButton_Click(object sender, RoutedEventArgs e)
+        {
+            Value = pathList.SelectedItem as string;
+            DialogResult = true;
+        }
+
+        private void MakeDarkTheme()
+        {
+            var converter = new BrushConverter();
+            if (App.Settings.settings.dark_mode)
+                Background = (Brush)converter.ConvertFromString("#FF171717");
+            else
+                Background = (Brush)converter.ConvertFromString("#FFFFFFFF");
+        }
+
+        private void pathList_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            installButton.IsEnabled = pathList.SelectedIndex != -1;
+        }
+
+        #endregion Private Methods
+    }
+}

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ A button to add a mod, a second one to delete a mod.
 ## Changelog
 
 - v0.0.9
+  - mods with no nativePC supported
+  - mods with multiple nativePC supported
 - v0.0.8
   - [FIXED] Now you can add a mod
   - Removed useless remove big button (you can remove a mod with the right click)


### PR DESCRIPTION
- Mod files with no nativePC will be seen as the nativePC folder itself instead of rejecting it. A message box will still show up to decide the fate of the mod.
- Mod files with multiple nativePC (different mod installations for example) will be prompted a window to choose which folder to pick instead of picking the first one automatically.
- colors added in debug mode for the console only.
- bumped to 0.0.9.